### PR TITLE
nginx: immediately close requests with spoofed domain names or ips

### DIFF
--- a/nginx/nginx.prod.conf
+++ b/nginx/nginx.prod.conf
@@ -1,3 +1,20 @@
+server{
+	listen 80;
+	server_name _;
+
+	return 444;
+}
+
+server{
+	listen 443;
+	server_name _;
+
+    ssl_certificate /etc/letsencrypt/live/${DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${DOMAIN}/privkey.pem;	
+
+	return 444;
+}
+
 server {
     listen 80;
     server_name ${DOMAIN} www.${DOMAIN};
@@ -10,8 +27,6 @@ server {
     location / {
         return 301 https://$host$request_uri;
     }
-
-
 }
 
 server {


### PR DESCRIPTION
someone can change request headers, so django app may get request with spoofed domain name or ip which are not in ALLOWED_HOSTS, so djnago will generate an error
solution: make nginx to don't pass that requests